### PR TITLE
Add simple breadcrumb-style parent taxa for groups

### DIFF
--- a/src/collection/display/EntryCardStack.tsx
+++ b/src/collection/display/EntryCardStack.tsx
@@ -2,17 +2,33 @@ import * as React from "react";
 import EntryCard from "./EntryCard";
 import EntryData from "../model/EntryData";
 import { Stack } from "@fluentui/react/lib/Stack";
+import { FontWeights, Image, Text, ITextStyles } from "@fluentui/react";
+import { TaxonomyLevel, TaxonomyLevels } from "../model/Taxonomy";
 
 interface EntryCardStackProps {
-  header: string;
+  groupLevel: { level: TaxonomyLevel; value: string };
   entries: EntryData[];
 }
 
 const EntryCardStack = (props: EntryCardStackProps) => {
-  const { header, entries } = props;
+  const { groupLevel, entries } = props;
+  const { level, value } = groupLevel;
+
+  const parentTaxa = TaxonomyLevels.map((l) => ({
+    level: l,
+    values: entries
+      .map((e) => e.taxonomy[l])
+      .filter((value, index, self) => self.indexOf(value) === index),
+  })).filter((_, index) => TaxonomyLevels.indexOf(level) > index);
+
   return (
     <div>
-      <span style={{ fontWeight: "bold" }}>{header}</span>
+      {parentTaxa.map((t) => (
+        <Text variant="mediumPlus" style={{ color: "#4C4A48" }}>{`${
+          t.values.length === 1 ? t.values[0] : "..."
+        } > `}</Text>
+      ))}
+      <span style={{ fontWeight: "bold" }}>{value}</span>
       <Stack horizontal wrap tokens={{ childrenGap: 10 }}>
         {entries.map((e) => (
           <EntryCard entry={e} />

--- a/src/collection/display/GroupedCollection.tsx
+++ b/src/collection/display/GroupedCollection.tsx
@@ -27,7 +27,10 @@ const GroupedCollection = (
   return (
     <Stack tokens={{ childrenGap: 10 }}>
       {groups.map((g) => (
-        <EntryCardStack entries={g.entries} header={g.groupName} />
+        <EntryCardStack
+          entries={g.entries}
+          groupLevel={{ value: g.groupName, level: groupLevel }}
+        />
       ))}
     </Stack>
   );


### PR DESCRIPTION
Closes #6 

For now, groups with multiple values for a parent taxa will have "..." for that level in the breadcrumbs. This looks decent for some cases like multiple undefined species in a family, but not as good if there are multiple undefined species across phyla. It may eventually be good to split up the "Not Specified" groups, but we'll see. 


